### PR TITLE
Fix for php notice in strict mode

### DIFF
--- a/disable-genesis-customizer-redirect.php
+++ b/disable-genesis-customizer-redirect.php
@@ -5,7 +5,7 @@
  * Description: Access the theme settings page without redirecting to customizer
  * Author:      Bill Erickson
  * Author URI:  https://www.billerickson.net
- * Version:     1.0.0
+ * Version:     1.0.1
  */
 
 /**
@@ -14,7 +14,7 @@
  */
 function be_disable_genesis_redirect() {
 	global $_genesis_admin_settings, $_genesis_admin_seo_settings;
-	$_genesis_admin_settings->redirect_to = false;
-	$_genesis_admin_seo_settings->redirect_to = false;
+	$_genesis_admin_settings->redirect_to = '/wp-admin/admin.php?page=genesis&noredirect';
+	$_genesis_admin_seo_settings->redirect_to = '/wp-admin/admin.php?page=seo-settings&noredirect';
 }
 add_action( 'genesis_admin_menu', 'be_disable_genesis_redirect', 11 );


### PR DESCRIPTION
I was seeing a notice with strict mode enabled for debugging (Notice: creating default object from empty value).

This is one possible fix for that, as if we set the actual value than we're no longer creating the object from an empty value.